### PR TITLE
enable creating ClientConfiguration

### DIFF
--- a/src/main/java/org/icann/czds/sdk/model/ClientConfiguration.java
+++ b/src/main/java/org/icann/czds/sdk/model/ClientConfiguration.java
@@ -54,7 +54,7 @@ public class ClientConfiguration {
     /**
      * If initiated using this constructor, you can specify location of file download
      * */
-    private ClientConfiguration(String userName, String password, String authenBaseUrl, String czdsBaseUrl, String workingDir) {
+    public ClientConfiguration(String userName, String password, String authenBaseUrl, String czdsBaseUrl, String workingDir) {
         setUserName(userName);
         setPassword(password);
         setAuthenticationBaseUrl(authenBaseUrl);


### PR DESCRIPTION
create configuration without having to use getInstance, as long as you pass the params you need